### PR TITLE
Bolder colors for light backgrounds

### DIFF
--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -5,11 +5,11 @@ import sys
 
 
 class bcolors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[96m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
+    HEADER = '\033[35m'
+    OKBLUE = '\033[34m'
+    OKGREEN = '\033[32m'
+    WARNING = '\033[33m'
+    FAIL = '\033[31m'
     ENDC = '\033[0m'
     BOLD = '\033[1m'
     UNDERLINE = '\033[4m'


### PR DESCRIPTION
This is better for Jenkins et al, where the background is white. Tested in jenkins using the ansi color plugin "xterm" setting.