### PR TITLE
Update script to handle old or new arn format

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The script makes every effort to avoid getting you into a bad place
 2. For simplicity, it follows a break one, make one pattern but does so in user defined batch size (default is 3 batches) to ensure a small loss in capacity.
 3. It will balk if the batch size equals the current capacity
 (because that will cause downtime).
-4. You can optional specify the ami id that you're upgrading to, which will allow it to skip instances that have already been upgraded. Otherwise, it will just replace all of your instances, in batches.
+4. You can optional specify the ami id that you're upgrading to, which will allow it to skip instances that have already been upgraded. Otherwise, it will just replace all of your instances, in batches. Add the flag ```--ami-id ami-youramiid```, to check instances first.
 
 WARNING: review your current autoscaling scaling configuration before using this script.
 
@@ -78,7 +78,7 @@ Usage:
 service-check --cluster-name dev-vpc-cluster-a --region us-east-1 your-ecs-service-name
 ```
 
-If the script detects a deployment that is not recent it considers it "stale" and waits for new info to show up. You must run this script within 2 minutes of updating your service/task_definition. You can increase the stale threshold by providing the flag ```--stale-s``` 
+If the script detects a deployment that is not recent it considers it "stale" and waits for new info to show up. You must run this script within 2 minutes of updating your service/task_definition. You can increase the stale threshold by providing the flag ```--stale-s SECONDS``` 
 
 ### kms-create
 

--- a/README.md
+++ b/README.md
@@ -50,10 +50,13 @@ The script makes every effort to avoid getting you into a bad place
 2. For simplicity, it follows a break one, make one pattern but does so in user defined batch size (default is 3 batches) to ensure a small loss in capacity.
 3. It will balk if the batch size equals the current capacity
 (because that will cause downtime).
+4. You can optional specify the ami id that you're upgrading to, which will allow it to skip instances that have already been upgraded. Otherwise, it will just replace all of your instances, in batches.
 
 WARNING: review your current autoscaling scaling configuration before using this script.
 
 This script does not rollback. If your new AMI is failing, the script will exit after the first batch is deployed and leave it to you to rollback the launch configuration (to the original AMI) and run the script again.
+
+NOTE: this script considers it's work complete once all instances have been terminated and your ECS services have been restored to a steady state.  e.g. if steady state has been acheived it won't wait for the last batch of instances to come up.
 
 Usage:
 ```
@@ -74,6 +77,8 @@ Usage:
 ```
 service-check --cluster-name dev-vpc-cluster-a --region us-east-1 your-ecs-service-name
 ```
+
+If the script detects a deployment that is not recent it considers it "stale" and waits for new info to show up. You must run this script within 2 minutes of updating your service/task_definition. You can increase the stale threshold by providing the flag ```--stale-s```
 
 ### kms-create
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ AWS provides many examples of best practices for ECS in the context of using Clo
 Have a recent version of python 3 (>= 3.6) and pip installed. Then install with pip.
 
 ```
-pip install git+git://github.com/navapbc/ecs-utils#egg=ecs-utils
+pip install git+git://github.com/navapbc/ecs-utils.git@v0.0.2
 ```
 
 ### Configure AWS access
@@ -78,7 +78,7 @@ Usage:
 service-check --cluster-name dev-vpc-cluster-a --region us-east-1 your-ecs-service-name
 ```
 
-If the script detects a deployment that is not recent it considers it "stale" and waits for new info to show up. You must run this script within 2 minutes of updating your service/task_definition. You can increase the stale threshold by providing the flag ```--stale-s```
+If the script detects a deployment that is not recent it considers it "stale" and waits for new info to show up. You must run this script within 2 minutes of updating your service/task_definition. You can increase the stale threshold by providing the flag ```--stale-s``` 
 
 ### kms-create
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ WARNING: review your current autoscaling scaling configuration before using this
 
 This script does not rollback. If your new AMI is failing, the script will exit after the first batch is deployed and leave it to you to rollback the launch configuration (to the original AMI) and run the script again.
 
-NOTE: this script considers it's work complete once all instances have been terminated and your ECS services have been restored to a steady state.  e.g. if steady state has been acheived it won't wait for the last batch of instances to come up.
+NOTE: this script considers its work complete once all instances have been terminated and your ECS services have been restored to a steady state.  e.g. if steady state has been acheived it won't wait for the last batch of instances to come up.
 
 Usage:
 ```

--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -139,7 +139,10 @@ def poll_cluster_state(ecs_client, cluster_name, service_names,
                         f'{service_name} tasks are still not healthy'
                     )
                     continue
-                services.remove(service_name)
+                if cluster_name in services[0]:
+                    services.remove(f'{cluster_name}/{service_name}') # 2019 arn format
+                else:
+                    services.remove(service_name)
                 elapsed = int(time.time() - start_time)
                 utils.print_success(
                     f'{service_name} is in a steady state. Elapsed: {elapsed}s'

--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -93,7 +93,7 @@ def tasks_are_healthy(ecs_client, cluster_name, service_name):
         if not next_token:
             break
 
-    utils.print_info(f'{service_name} all {healthy} tasks are healthy')
+    utils.print_info(f'{service_name} {healthy} tasks are healthy')
     return True
 
 
@@ -104,9 +104,8 @@ def poll_cluster_state(ecs_client, cluster_name, service_names,
     """
 
     utils.print_info(
-        f'Polling services: {service_names} in cluster: {cluster_name}'
+        f'Polling services: {service_names} in cluster: {cluster_name} with timeout: {polling_timeout}s'
     )
-    utils.print_info(f'Timeout is {polling_timeout}s')
     start_time = time.time()
     services = service_names.copy()
     last_response = []

--- a/scripts/rolling_replace.py
+++ b/scripts/rolling_replace.py
@@ -115,6 +115,7 @@ def batch_instances(instances, batch_count):
 
 def rolling_replace_instances(ecs, ec2, cluster_name, batches, ami_id, force):
 
+    replace_start_time = time.time()
     services = get_services(ecs, cluster_name)
     if not services:
         raise RollingException('No services found in cluster. exiting.')
@@ -184,7 +185,7 @@ def rolling_replace_instances(ecs, ec2, cluster_name, batches, ami_id, force):
         # we wait for ECS to resume a steady state before moving on
         ecs_utils.poll_cluster_state(ecs, cluster_name,
                                      services, polling_timeout=TIMEOUT_S)
-    utils.print_success('EC2 instance replacement complete!')
+    utils.print_success(f'EC2 instance replacement process complete! {int(time.time() - replace_start_time)}s elapsed')
 
 
 def main():

--- a/scripts/rolling_replace.py
+++ b/scripts/rolling_replace.py
@@ -163,7 +163,7 @@ def rolling_replace_instances(ecs, ec2, cluster_name, batches, ami_id, force):
         ecs.update_container_instances_state(cluster=cluster_name,
                                              status='DRAINING',
                                              containerInstances=to_drain)
-        utils.print_info('wait for drain to complete...')
+        utils.print_info(f'Wait for drain to complete with {TIMEOUT_S}s timeout...')
         start_time = time.time()
         while len(done_instances) < len(to_drain):
             if (time.time() - start_time) > TIMEOUT_S:

--- a/scripts/service_check.py
+++ b/scripts/service_check.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-Polls until an ECS service shows a completed deployment.
-(i.e. it has completed its scheduling instructions)
+Polls until a deployed ECS service to verify a completed deployment.
+(i.e. ECS has completed its scheduling instructions)
 NOTE: this should be run immediately after a service update.
 If the script detects a deployment that is not recent it considers it
 "stale", if older than STALE_S
@@ -14,7 +14,7 @@ import time
 from scripts import utils
 from scripts import ecs_utils
 
-STALE_S = 60
+STALE_S = 120
 
 
 def parse_args():

--- a/tests/ecs_utils_test.py
+++ b/tests/ecs_utils_test.py
@@ -66,6 +66,14 @@ class EcsTestCase(TestCase):
         mock_client.describe_tasks.return_value = GOOD_TASKS
         ecs_utils.poll_cluster_state(mock_client, 'cluster-foo', ['service-foo'], POLL_S)
 
+    @patch('boto3.client')
+    def test_poll_cluster_new_arn(self, mock_boto):
+        mock_client = mock_boto.return_value
+        mock_client.describe_services.return_value = GOOD_SERVICE
+        mock_client.list_tasks.return_value = TASKS
+        mock_client.describe_tasks.return_value = GOOD_TASKS
+        ecs_utils.poll_cluster_state(mock_client, 'cluster-foo', ['cluster-foo/service-foo'], POLL_S)
+
     @patch('scripts.ecs_utils.print_events')
     @patch('boto3.client')
     def test_poll_cluster_timeout(self, mock_boto, mock_print_events):

--- a/tests/param_test.py
+++ b/tests/param_test.py
@@ -25,7 +25,7 @@ class ParamTestCase(TestCase):
 
         mock_client = mock_boto.return_value
         mock_client.get_parameter.return_value = 'test'
-        self.assertEquals(get_param('foo','us-east-1'), 'test')
+        self.assertEqual(get_param('foo','us-east-1'), 'test')
         mock_client.get_parameter.side_effect = botocore.exceptions.ClientError(error_response,'put_parameter')
         with self.assertRaises(SystemExit):
             get_param('foo', 'us-east-1')

--- a/tests/rolling_replace_test.py
+++ b/tests/rolling_replace_test.py
@@ -12,7 +12,7 @@ rolling_replace.DRAIN_TIMEOUT_S = 10
 rolling_replace.SLEEP_TIME_S = 0
 
 GOOD_SERVICE = {
-    'serviceArns': ['service/foo'],
+    'serviceArns': ['cluster-foo/service/foo'],
     'services': [{
         'serviceName': 'service-foo',
         'runningCount': 2,


### PR DESCRIPTION
AWS has a new arn format. This change will accommodate either format. I've also made some small changes:
- better docs
- better default "stale" threshold for service-check script (2 minutes)
- longer timeout for waiting for draining to complete to account for the case where ECS can't drain (terminate tasks) in the current instance until the previous batch of instances are up. Basically wait longer.

Testing:
- [x] added unit test for arn change
- [x] ran a few deploys