### PR TITLE
Increase timeout for particularly long scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It fits into a deployment pattern where the Autoscaling Group resource is update
 
 1. Set an instance to draining (see: AWS docs on container instance draining)
 2. Wait for it to drain
-   (recommendation: lower the AWS default deregistration delay of 300s)
+   (recommendation: lower the AWS lb deregistration delay from its 300s default)
 3. Terminate the instance
 4. Wait for the new instance (with the new AMI) to launch and tasks to
    be scheduled there and tasks to pass container health checks.

--- a/scripts/rolling_replace.py
+++ b/scripts/rolling_replace.py
@@ -116,7 +116,7 @@ def batch_instances(instances, batch_count):
     return batches
 
 
-def rolling_replace_instances(ecs, ec2, cluster_name, batches, ami_id, force):
+def rolling_replace_instances(ecs, ec2, cluster_name, batches, ami_id, force, drain_timeout_s):
 
     replace_start_time = time.time()
     services = get_services(ecs, cluster_name)

--- a/scripts/rolling_replace.py
+++ b/scripts/rolling_replace.py
@@ -23,7 +23,7 @@ SLEEP_TIME_S = 5
 # polling timeout for ECS steady state after instance launch, or for draining
 # note, in some cases, instances will not finish draining until the previous
 # batch of instances are live.
-TIMEOUT_S = 900
+TIMEOUT_S = 1200
 
 def parse_args():
     parser = argparse.ArgumentParser(
@@ -37,6 +37,9 @@ def parse_args():
                         help='Number of batches in replacing instances')
     parser.add_argument('--ami-id',
                         help='AMI ID to verify in new instances.')
+    parser.add_argument('--drain-timeout-s',
+                        default=TIMEOUT_S,
+                        help='Time to wait for instances to complete draining.')
     parser.add_argument('--force', '-f',
                         help="Ignore downtime warning due to capacity.",
                         default=False,
@@ -163,10 +166,10 @@ def rolling_replace_instances(ecs, ec2, cluster_name, batches, ami_id, force):
         ecs.update_container_instances_state(cluster=cluster_name,
                                              status='DRAINING',
                                              containerInstances=to_drain)
-        utils.print_info(f'Wait for drain to complete with {TIMEOUT_S}s timeout...')
+        utils.print_info(f'Wait for drain to complete with {drain_timeout_s}s timeout...')
         start_time = time.time()
         while len(done_instances) < len(to_drain):
-            if (time.time() - start_time) > TIMEOUT_S:
+            if (time.time() - start_time) > drain_timeout_s:
                 raise RollingTimeoutException('Waiting for instance to complete draining. Giving up.')
             time.sleep(SLEEP_TIME_S)
             response = ecs.describe_container_instances(
@@ -182,9 +185,9 @@ def rolling_replace_instances(ecs, ec2, cluster_name, batches, ami_id, force):
                     ec2.terminate_instances(InstanceIds=[instance_id])
                     done_instances.append(instance_id)
         # new instance will take as much as 10m to go into service
-        # we wait for ECS to resume a steady state before moving on
+        # then we wait for ECS to resume a steady state before moving on
         ecs_utils.poll_cluster_state(ecs, cluster_name,
-                                     services, polling_timeout=TIMEOUT_S)
+                                     services, polling_timeout=drain_timeout_s)
     utils.print_success(f'EC2 instance replacement process complete! {int(time.time() - replace_start_time)}s elapsed')
 
 
@@ -193,7 +196,8 @@ def main():
     ecs = boto3.client('ecs', args.region)
     ec2 = boto3.client('ec2', args.region)
     rolling_replace_instances(ecs, ec2, args.cluster_name,
-                              int(args.batches), args.ami_id, args.force)
+                              int(args.batches), args.ami_id, args.force,
+                              args.drain_timeout_s)
 
 
 if __name__ == '__main__':

--- a/scripts/rolling_replace.py
+++ b/scripts/rolling_replace.py
@@ -197,7 +197,7 @@ def main():
     ec2 = boto3.client('ec2', args.region)
     rolling_replace_instances(ecs, ec2, args.cluster_name,
                               int(args.batches), args.ami_id, args.force,
-                              args.drain_timeout_s)
+                              int(args.drain_timeout_s))
 
 
 if __name__ == '__main__':

--- a/tests/rolling_replace_test.py
+++ b/tests/rolling_replace_test.py
@@ -7,7 +7,7 @@ import scripts.rolling_replace as rolling_replace
 
 # note: we override time.time()
 rolling_replace.TIMEOUT_S = 10
-rolling_replace.DRAIN_TIMEOUT_S = 10
+TIMEOUT_S = rolling_replace.TIMEOUT_S
 # reduce polling time to speed tests
 rolling_replace.SLEEP_TIME_S = 0
 
@@ -70,7 +70,7 @@ class RollingTestCase(TestCase):
         mock_client.list_container_instances.return_value = INSTANCE_ARNS
         mock_client.describe_container_instances.side_effect = MOCK_RESPONSES
         rolling_replace.rolling_replace_instances(
-            mock_client, mock_client, 'cluster-foo', 2, '', False
+            mock_client, mock_client, 'cluster-foo', 2, '', False, TIMEOUT_S
         )
 
     @patch("scripts.utils.print_warning")
@@ -83,7 +83,7 @@ class RollingTestCase(TestCase):
         mock_client.list_container_instances.return_value = INSTANCE_ARNS
         mock_client.describe_container_instances.side_effect = MOCK_RESPONSES
         rolling_replace.rolling_replace_instances(
-            mock_client, mock_client, 'cluster-foo', 2, 'ami1', False
+            mock_client, mock_client, 'cluster-foo', 2, 'ami1', False, TIMEOUT_S
         )
         mock_warn.assert_called_with(
             'biz already uses ami_id ami1. Skipping.')
@@ -97,7 +97,7 @@ class RollingTestCase(TestCase):
         mock_client.list_container_instances.return_value = INSTANCE_ARNS
         mock_client.describe_container_instances.side_effect = MOCK_RESPONSES
         rolling_replace.rolling_replace_instances(
-            mock_client, mock_client, 'cluster-foo', 2, 'ami2', False
+            mock_client, mock_client, 'cluster-foo', 2, 'ami2', False, TIMEOUT_S
         )
 
     @patch('scripts.ecs_utils.poll_cluster_state')
@@ -116,7 +116,7 @@ class RollingTestCase(TestCase):
         mock_client.describe_container_instances.side_effect = responses
         with self.assertRaises(rolling_replace.RollingTimeoutException):
             rolling_replace.rolling_replace_instances(
-                mock_client, mock_client, 'cluster-foo', 2, '', False
+                mock_client, mock_client, 'cluster-foo', 2, '', False, TIMEOUT_S
             )
 
     @patch("scripts.utils.print_warning")
@@ -130,7 +130,7 @@ class RollingTestCase(TestCase):
         with self.assertRaises(rolling_replace.RollingException):
             # batch size of 1 will take your service down
             rolling_replace.rolling_replace_instances(
-                mock_client, mock_client, 'cluster-foo', 1, '', False
+                mock_client, mock_client, 'cluster-foo', 1, '', False, TIMEOUT_S
             )
         mock_warn.assert_called_with(
             'Terminating 2 instances will cause downtime.'
@@ -141,5 +141,5 @@ class RollingTestCase(TestCase):
         mock_client = mock_boto.return_value
         with self.assertRaises(rolling_replace.RollingException):
             rolling_replace.rolling_replace_instances(
-                mock_client, mock_client, 'cluster-foo', 3, '', False
+                mock_client, mock_client, 'cluster-foo', 3, '', False, TIMEOUT_S
             )


### PR DESCRIPTION
Depending on the scenario, the time waiting for the first batch of instances to be up and the 2nd batch to finally be able to drain, sometimes exceeds 900s. Increased the default to 1200 and provided a flag.