### PR TITLE
Increase rolling replace initial service check timeout

### DIFF
--- a/scripts/rolling_replace.py
+++ b/scripts/rolling_replace.py
@@ -126,7 +126,7 @@ def rolling_replace_instances(ecs, ec2, cluster_name, batches, ami_id, force, dr
         f'Checking cluster {cluster_name}, services {str(services)} are stable'
     )
     ecs_utils.poll_cluster_state(
-        ecs, cluster_name, services, polling_timeout=30
+        ecs, cluster_name, services, polling_timeout=120
     )
     instances = get_container_instance_arns(ecs, cluster_name)
     # batches determines the number of instances you want to replace at once.


### PR DESCRIPTION
The rolling replace does an initial check for service stability. Life being as it is, 30s is just too tight for unforseen issues. Can't hurt to up it to 120s.