### PR TITLE
Add a script to get the latest running docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 ecs-utils is a collection of useful python scripts and libraries for use with AWS Elastic Container Service (ECS). The scripts:
 - rolling-replace: performs a no-downtime replacement of instances in an ECS cluster (autoscaling group)
 - service-check: polls an ECS service for health (deployment completion)
+- get-current-image: finds the current docker image url for a given service
 - param: a wrapper script for interacting with AWS Parameter store
 - kms-create: wrapper for creating kms keys
 - kms-crypt: wrapper for creating kms encrypted data

--- a/scripts/get_current_image.py
+++ b/scripts/get_current_image.py
@@ -26,7 +26,6 @@ def parse_args():
 def get_ecs_image_url(client, cluster, service):
     """Gets the current docker image url of an ECS service"""
 
-
     try:
         task_definition = client.describe_services(
             cluster=cluster, services=[service]

--- a/scripts/get_current_image.py
+++ b/scripts/get_current_image.py
@@ -44,10 +44,12 @@ def get_ecs_image_url(client, cluster, service):
     
     return image
 
+def get_client(region):
+    return boto3.client('ecs', args.region)
 
 def main():
     args = parse_args()
-    client = boto3.client('ecs', args.region)
+    client = get_client(args.region)
     sys.stdout.write(get_ecs_image_url(client, args.cluster, args.service))
 
 

--- a/scripts/get_current_image.py
+++ b/scripts/get_current_image.py
@@ -11,7 +11,7 @@ from scripts import utils
 
 
 def parse_args():
-    parser = argparse.ArgumentParser(description='create KMS key')
+    parser = argparse.ArgumentParser(description='Get the current docker image for an ECS service.')
 
     parser.add_argument('--region','-r', required=True,
                         help='AWS region')

--- a/scripts/get_current_image.py
+++ b/scripts/get_current_image.py
@@ -30,12 +30,16 @@ def get_ecs_image_url(client, cluster, service):
         task_definition = client.describe_services(
             cluster=cluster, services=[service]
         ).get('services')[0].get('taskDefinition')
+    except Exception as err:
+        print(f'Service lookup failed: {err}')
+        sys.exit(1)
 
+    try: 
         image = client.describe_task_definition(
             taskDefinition=task_definition
         ).get('taskDefinition').get('containerDefinitions')[0].get('image')
     except Exception as err:
-        print(f'Task/Service lookup failed: {err}')
+        print(f'Task lookup failed: {err}')
         sys.exit(1)
     
     return image

--- a/scripts/get_current_image.py
+++ b/scripts/get_current_image.py
@@ -45,7 +45,7 @@ def get_ecs_image_url(client, cluster, service):
     return image
 
 def get_client(region):
-    return boto3.client('ecs', args.region)
+    return boto3.client('ecs', region)
 
 def main():
     args = parse_args()

--- a/scripts/get_current_image.py
+++ b/scripts/get_current_image.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""
+Returns the latest image running in an ECS service
+"""
+import boto3
+import base64
+import argparse
+import sys
+
+from scripts import utils
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='create KMS key')
+
+    parser.add_argument('--region','-r', required=True,
+                        help='AWS region')
+    parser.add_argument('--cluster','-c',
+                        help='ECS cluster name')
+    parser.add_argument('--service','-s',
+                        help='ECS service name')
+    return parser.parse_args()
+
+
+
+def get_ecs_image_url(client, cluster, service):
+    """Gets the current docker image url of an ECS service"""
+
+
+    try:
+        task_definition = client.describe_services(
+            cluster=cluster, services=[service]
+        ).get('services')[0].get('taskDefinition')
+
+        image = client.describe_task_definition(
+            taskDefinition=task_definition
+        ).get('taskDefinition').get('containerDefinitions')[0].get('image')
+    except Exception as err:
+        print(f'Task/Service lookup failed: {err}')
+        sys.exit(1)
+    
+    return image
+
+
+def main():
+    args = parse_args()
+    client = boto3.client('ecs', args.region)
+    print(get_ecs_image_url(client, args.cluster, args.service))
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/get_current_image.py
+++ b/scripts/get_current_image.py
@@ -31,7 +31,7 @@ def get_ecs_image_url(client, cluster, service):
             cluster=cluster, services=[service]
         ).get('services')[0].get('taskDefinition')
     except Exception as err:
-        print(f'Service lookup failed: {err}')
+        sys.stderr.write(f'Service lookup failed: {err}')
         sys.exit(1)
 
     try: 
@@ -39,7 +39,7 @@ def get_ecs_image_url(client, cluster, service):
             taskDefinition=task_definition
         ).get('taskDefinition').get('containerDefinitions')[0].get('image')
     except Exception as err:
-        print(f'Task lookup failed: {err}')
+        sys.stderr.write(f'Task lookup failed: {err}')
         sys.exit(1)
     
     return image
@@ -48,7 +48,7 @@ def get_ecs_image_url(client, cluster, service):
 def main():
     args = parse_args()
     client = boto3.client('ecs', args.region)
-    print(get_ecs_image_url(client, args.cluster, args.service))
+    sys.stdout.write(get_ecs_image_url(client, args.cluster, args.service))
 
 
 if __name__ == '__main__':

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
             "kms-crypt = scripts.kms_crypt:main",
             "param = scripts.param:main",
             "service-check = scripts.service_check:main",
+            "get-current-image = scripts.get_current_image:main",
             "rolling-replace = scripts.rolling_replace:main"
         ],
     },

--- a/tests/get_current_image_test.py
+++ b/tests/get_current_image_test.py
@@ -1,0 +1,44 @@
+"""Test case for get-current-image"""
+import botocore
+import unittest
+from unittest import TestCase
+from unittest.mock import patch
+from scripts.get_current_image import get_ecs_image_url
+
+GOOD_SERVICE = {
+    'services': [{
+        'taskDefinition': 'arn:aws:test_task_definition',
+    }]
+}
+
+GOOD_TASKD = {
+    'taskDefinition': {
+        'containerDefinitions' : [{
+            'image': '123.amazonaws.com/test_service:latest'
+        }]
+    }
+}
+
+
+class ImageTestCase(TestCase):
+    """Test the ecs image utility."""
+
+    @patch('boto3.client')
+    def test_positive(self,mock_boto):
+        mock_client = mock_boto.return_value
+        mock_client.describe_services.return_value = GOOD_SERVICE
+        mock_client.describe_task_definition.return_value = GOOD_TASKD
+        image = get_ecs_image_url(mock_client, 'cluster-foo', 'service-foo')
+        mock_client.describe_task_definition.assert_called_with(taskDefinition='arn:aws:test_task_definition')
+        assert(image == '123.amazonaws.com/test_service:latest')
+
+    @patch('boto3.client')
+    def test_no_task(self,mock_boto):
+        mock_client = mock_boto.return_value
+        mock_client.describe_services.return_value = GOOD_SERVICE
+        mock_client.describe_task_definition.return_value = {}
+        with self.assertRaises(SystemExit):
+            get_ecs_image_url(mock_client, 'cluster-foo', 'service-foo')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
adds get-current-image: finds the current docker image url for a given service. This script is useful e.g. for comparing the proposed docker image to deploy vs. what is currently deployed.

Testing:
- [x] unit tests added
- [x] tested a basic positive case manually