### PR TITLE
Fix poll_cluster_state when cluster and service name are the same

### DIFF
--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -108,6 +108,7 @@ def poll_cluster_state(ecs_client, cluster_name, service_names,
     )
     start_time = time.time()
     services = service_names.copy()
+    is_2019_arn_format = services[0].startswith(f'{cluster_name}/')
     last_response = []
     while services:
         time.sleep(SLEEP_TIME_S)
@@ -138,8 +139,8 @@ def poll_cluster_state(ecs_client, cluster_name, service_names,
                         f'{service_name} tasks are still not healthy'
                     )
                     continue
-                if services[0].startswith(f'{cluster_name}/'):
-                    services.remove(f'{cluster_name}/{service_name}') # 2019 arn format
+                if is_2019_arn_format:
+                    services.remove(f'{cluster_name}/{service_name}')
                 else:
                     services.remove(service_name)
                 elapsed = int(time.time() - start_time)

--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -138,7 +138,7 @@ def poll_cluster_state(ecs_client, cluster_name, service_names,
                         f'{service_name} tasks are still not healthy'
                     )
                     continue
-                if cluster_name in services[0]:
+                if services[0].startswith(f'{cluster_name}/'):
                     services.remove(f'{cluster_name}/{service_name}') # 2019 arn format
                 else:
                     services.remove(service_name)

--- a/tests/ecs_utils_test.py
+++ b/tests/ecs_utils_test.py
@@ -74,6 +74,14 @@ class EcsTestCase(TestCase):
         mock_client.describe_tasks.return_value = GOOD_TASKS
         ecs_utils.poll_cluster_state(mock_client, 'cluster-foo', ['cluster-foo/service-foo'], POLL_S)
 
+    @patch('boto3.client')
+    def test_poll_cluster_matching_cluster_and_service_name(self, mock_boto):
+        mock_client = mock_boto.return_value
+        mock_client.describe_services.return_value = GOOD_SERVICE
+        mock_client.list_tasks.return_value = TASKS
+        mock_client.describe_tasks.return_value = GOOD_TASKS
+        ecs_utils.poll_cluster_state(mock_client, 'service-foo', ['service-foo'], POLL_S)
+
     @patch('scripts.ecs_utils.print_events')
     @patch('boto3.client')
     def test_poll_cluster_timeout(self, mock_boto, mock_print_events):


### PR DESCRIPTION
For example, in BEDAP, `BEDAP-dev-api` is the name for both the cluster
and only service in the cluster. This breaks the `rolling_release.py`
script for that service.

@bneutra @wcleong