### PR TITLE
Check if service is active before probing tasks

### DIFF
--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -67,6 +67,12 @@ def service_is_stable(service_response):
     utils.print_progress()
     return False
 
+def service_is_active(service_response):
+    desired = service_response.get('desiredCount')
+    if desired == 0:
+        return False
+    utils.print_progress()
+    return True
 
 # After tasks show as RUNNING they may not be healthy, you must check that.
 def tasks_are_healthy(ecs_client, cluster_name, service_name):
@@ -133,7 +139,7 @@ def poll_cluster_state(ecs_client, cluster_name, service_names,
                     continue
             service_name = service_response.get('serviceName')
             if service_is_stable(service_response):
-                if not tasks_are_healthy(ecs_client, cluster_name,
+                if service_is_active(service_response) and not tasks_are_healthy(ecs_client, cluster_name,
                                          service_name):
                     utils.print_warning(
                         f'{service_name} tasks are still not healthy'

--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -134,6 +134,7 @@ def poll_cluster_state(ecs_client, cluster_name, service_names,
             is_active = service_response.get('desiredCount') > 0
             
             if service_is_stable(service_response):
+                # only check services that are active (desiredCount > 0)
                 if is_active and not tasks_are_healthy(ecs_client, cluster_name,
                                          service_name):
                     utils.print_warning(

--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -67,13 +67,6 @@ def service_is_stable(service_response):
     utils.print_progress()
     return False
 
-def service_is_active(service_response):
-    desired = service_response.get('desiredCount')
-    if desired == 0:
-        return False
-    utils.print_progress()
-    return True
-
 # After tasks show as RUNNING they may not be healthy, you must check that.
 def tasks_are_healthy(ecs_client, cluster_name, service_name):
 
@@ -138,8 +131,10 @@ def poll_cluster_state(ecs_client, cluster_name, service_names,
                 if not has_recent_event(service_response, start_time, stale_s):
                     continue
             service_name = service_response.get('serviceName')
+            is_active = service_response.get('desiredCount') > 0
+            
             if service_is_stable(service_response):
-                if service_is_active(service_response) and not tasks_are_healthy(ecs_client, cluster_name,
+                if is_active and not tasks_are_healthy(ecs_client, cluster_name,
                                          service_name):
                     utils.print_warning(
                         f'{service_name} tasks are still not healthy'


### PR DESCRIPTION
When the desiredCount for a service is set to 0, `ecs_client.describe_tasks` throws an InvalidParameterException due to an empty task list.

Testing:

[x] unit test added
[x] tested a basic positive case manually