### PR TITLE
Raise instead of exit

### DIFF
--- a/scripts/get_current_image.py
+++ b/scripts/get_current_image.py
@@ -32,7 +32,7 @@ def get_ecs_image_url(client, cluster, service):
         ).get('services')[0].get('taskDefinition')
     except Exception as err:
         sys.stderr.write(f'Service lookup failed: {err}')
-        sys.exit(1)
+        raise err
 
     try: 
         image = client.describe_task_definition(
@@ -40,7 +40,7 @@ def get_ecs_image_url(client, cluster, service):
         ).get('taskDefinition').get('containerDefinitions')[0].get('image')
     except Exception as err:
         sys.stderr.write(f'Task lookup failed: {err}')
-        sys.exit(1)
+        raise err
     
     return image
 

--- a/tests/get_current_image_test.py
+++ b/tests/get_current_image_test.py
@@ -37,7 +37,7 @@ class ImageTestCase(TestCase):
         mock_client = mock_boto.return_value
         mock_client.describe_services.return_value = GOOD_SERVICE
         mock_client.describe_task_definition.return_value = {}
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(AttributeError):
             get_ecs_image_url(mock_client, 'cluster-foo', 'service-foo')
 
 if __name__ == '__main__':


### PR DESCRIPTION
A failure of a lookup in a calling script (not here) made me realize why having a method sys.exit is not good: no stack trace, no clue why your script exited. So, I switch to raise.

Tests were updated and are passing