### PR TITLE
service-check should base health on rolloutState

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Note: the script assumes that you have container health checks configured for an
 
 ### service-check
 
-This script polls an ECS service after a task configuration change (e.g. docker image update) and returns 0 when all tasks show container 'HEALTHY' and the deployment 'PRIMARY' with the desired number of tasks running.
+This script polls an ECS service after a task configuration change (e.g. docker image update) and returns 0 when all tasks show container 'HEALTHY' and the deployment 'PRIMARY' has a rolloutState of 'COMPLETED' with the desired number of tasks running. This check is meant for rolling deploy ECS services.
 
 Usage:
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
-boto3>=1.8.5
-botocore>=1.11.5
-pre-commit>=1.10.5
-pytest<=3.7.4
-virtualenv>=16.0.0
+boto3>=1.18
+botocore>=1.21
+pytest>=6.2

--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -37,8 +37,6 @@ def deployment_is_stable(deployment, start_time, stale_s):
     status = deployment.get('status')
     rolloutState = deployment.get('rolloutState')
     age_s = start_time - int(dt)
-    print(rolloutState)
-    print(status)
     if stale_s and (age_s > stale_s):
         utils.print_warning(
             f'Deployment state info may be stale ({int(age_s)}s), polling'

--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -128,7 +128,6 @@ def poll_cluster_state(ecs_client, cluster_name, service_names,
             if stale_s:
                 # check that the service has started to change based on events
                 if not has_recent_event(service_response, start_time, stale_s):
-                    print('not had recent')
                     continue
             service_name = service_response.get('serviceName')
             is_active = service_response.get('desiredCount') > 0

--- a/scripts/ecs_utils.py
+++ b/scripts/ecs_utils.py
@@ -35,13 +35,16 @@ def deployment_is_stable(deployment, start_time, stale_s):
     running = deployment.get('runningCount')
     desired = deployment.get('desiredCount')
     status = deployment.get('status')
+    rolloutState = deployment.get('rolloutState')
     age_s = start_time - int(dt)
+    print(rolloutState)
+    print(status)
     if stale_s and (age_s > stale_s):
         utils.print_warning(
             f'Deployment state info may be stale ({int(age_s)}s), polling'
         )
         return False
-    if (running == desired) and status == 'PRIMARY':
+    if (running == desired) and status == 'PRIMARY' and rolloutState == 'COMPLETED':
         return True
     return False
 

--- a/scripts/rolling_replace.py
+++ b/scripts/rolling_replace.py
@@ -17,8 +17,6 @@ import time
 from scripts import utils
 from scripts import ecs_utils
 
-PRINT_PROGRESS = utils.print_progress
-
 SLEEP_TIME_S = 5
 # polling timeout for ECS steady state after instance launch, or for draining
 # note, in some cases, instances will not finish draining until the previous
@@ -178,7 +176,7 @@ def rolling_replace_instances(ecs, ec2, cluster_name, batches, ami_id, force, dr
                 instance_id = container_instance.get('ec2InstanceId')
                 running_tasks = container_instance.get('runningTasksCount')
                 if running_tasks > 0:
-                    PRINT_PROGRESS()
+                    utils.print_progress()
                     continue
                 if instance_id not in done_instances:
                     utils.print_info(f'{instance_id} is drained, terminate!')

--- a/scripts/service_check.py
+++ b/scripts/service_check.py
@@ -15,7 +15,7 @@ from scripts import utils
 from scripts import ecs_utils
 
 STALE_S = 120
-POLLING_TIMEOUT = 300
+POLLING_TIMEOUT = 360
 
 def parse_args():
     parser = argparse.ArgumentParser(description = 'Checks an ECS service status')


### PR DESCRIPTION

We were previously checking that the PRIMARY deploy had desired=running tasks but this was incorrect it resulted in a race where service-check completed but the deploy wasn't completely finished (e.g. one new task was running but an old task was still in service)  This should ensure that the deploy is complete (all old tasks are gone, new tasks are up and running and, if applicable, passing self and lb target health checks)

Testing:
- [x] added unit test
- [x] did a couple of manual deploys to verify this new criteria works properly